### PR TITLE
Add new fall damage mixin for planet gravity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.hrznstudio'
-version "0.2.7-alpha+${project.mc}"
+version "0.2.8-alpha+${project.mc}"
 archivesBaseName = 'GalacticraftAPI'
 
 sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/LivingEntityMixin.java
@@ -4,10 +4,18 @@ import com.hrznstudio.galacticraft.api.celestialbodies.CelestialBodyType;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Optional;
 
@@ -22,5 +30,23 @@ public abstract class LivingEntityMixin extends Entity {
     private double modifyGravity(double d) {
         Optional<CelestialBodyType> type = CelestialBodyType.getByDimType(((LivingEntity)(Object)this).world.getRegistryKey());
         return type.map(celestialBodyType -> celestialBodyType.getGravity() * 0.08d).orElse(0.08d);
+    }
+
+    @Shadow
+    protected abstract int getNextAirUnderwater(int air);
+
+    @Shadow
+    public abstract StatusEffectInstance getStatusEffect(StatusEffect effect);
+
+    @Inject(method = "computeFallDamage", at = @At("HEAD"), cancellable = true)
+    protected void onComputeFallDamage(float fallDistance, float damageMultiplier, CallbackInfoReturnable<Integer> cir) {
+        RegistryKey<World> worldRegistryKey = this.world.getRegistryKey();
+        for (CelestialBodyType body : CelestialBodyType.getAll()) {
+            if (body.getWorld() == worldRegistryKey) {
+                StatusEffectInstance statusEffectInstanc = this.getStatusEffect(StatusEffects.JUMP_BOOST);
+                float ff = statusEffectInstanc == null ? 0.0F : (float) (statusEffectInstanc.getAmplifier() + 6);
+                cir.setReturnValue(MathHelper.ceil(((fallDistance / (1 / body.getGravity())) - 3.0F - ff) * damageMultiplier));
+            }
+        }
     }
 }

--- a/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/LivingEntityMixin.java
@@ -41,12 +41,11 @@ public abstract class LivingEntityMixin extends Entity {
     @Inject(method = "computeFallDamage", at = @At("HEAD"), cancellable = true)
     protected void onComputeFallDamage(float fallDistance, float damageMultiplier, CallbackInfoReturnable<Integer> cir) {
         RegistryKey<World> worldRegistryKey = this.world.getRegistryKey();
-        for (CelestialBodyType body : CelestialBodyType.getAll()) {
-            if (body.getWorld() == worldRegistryKey) {
-                StatusEffectInstance statusEffectInstanc = this.getStatusEffect(StatusEffects.JUMP_BOOST);
-                float ff = statusEffectInstanc == null ? 0.0F : (float) (statusEffectInstanc.getAmplifier() + 6);
-                cir.setReturnValue(MathHelper.ceil(((fallDistance / (1 / body.getGravity())) - 3.0F - ff) * damageMultiplier));
-            }
+        CelestialBodyType body = CelestialBodyType.getByDimType(worldRegistryKey).get();
+        if (body != null) {
+            StatusEffectInstance statusEffectInstanc = this.getStatusEffect(StatusEffects.JUMP_BOOST);
+            float ff = statusEffectInstanc == null ? 0.0F : (float) (statusEffectInstanc.getAmplifier() + 6);
+            cir.setReturnValue(MathHelper.ceil(((fallDistance / (1 / body.getGravity())) - 3.0F - ff) * damageMultiplier));
         }
     }
 }


### PR DESCRIPTION
This should work for every celestial body, dynamically. Because of how the calculation is set up, Earth fall damage stays the same.