### PR TITLE
Feat: add custom gravity to block break particle

### DIFF
--- a/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/ClientBlockDustParticleMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/ClientBlockDustParticleMixin.java
@@ -25,9 +25,6 @@ public abstract class ClientBlockDustParticleMixin extends Particle {
         Optional<CelestialBodyType> body = CelestialBodyType.getByDimType(worldRegistryKey);
         if (body.isPresent()) {
             this.gravityStrength = body.get().getGravity();
-        } else {
-            // Nether, End, potentially other modded dimensions
-            this.gravityStrength = 1.0f;
         }
     }
 }

--- a/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/ClientBlockDustParticleMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/ClientBlockDustParticleMixin.java
@@ -1,0 +1,33 @@
+package com.hrznstudio.galacticraft.api.internal.mixin;
+
+import com.hrznstudio.galacticraft.api.celestialbodies.CelestialBodyType;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.particle.BlockDustParticle;
+import net.minecraft.client.particle.Particle;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Optional;
+
+@Mixin(BlockDustParticle.class)
+public abstract class ClientBlockDustParticleMixin extends Particle {
+    public ClientBlockDustParticleMixin(ClientWorld world, double x, double y, double z, double velocityX, double velocityY, double velocityZ) {super(world, x, y, z, velocityX, velocityY, velocityZ);}
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    protected void BlockDustParticle(ClientWorld world, double x, double y, double z, double velocityX, double velocityY, double velocityZ, BlockState blockState, CallbackInfo ci) {
+        this.gravityStrength = 1.0f;
+        RegistryKey<World> worldRegistryKey = world.getRegistryKey();
+        Optional<CelestialBodyType> body = CelestialBodyType.getByDimType(worldRegistryKey);
+        if (body.isPresent()) {
+            this.gravityStrength = body.get().getGravity();
+        } else {
+            // Nether, End, potentially other modded dimensions
+            this.gravityStrength = 1.0f;
+        }
+    }
+}

--- a/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/ClientParticleMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/ClientParticleMixin.java
@@ -1,0 +1,34 @@
+package com.hrznstudio.galacticraft.api.internal.mixin;
+
+import com.hrznstudio.galacticraft.api.celestialbodies.CelestialBodyType;
+import net.minecraft.client.particle.Particle;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Optional;
+
+@Mixin(Particle.class)
+public abstract class ClientParticleMixin {
+
+    @Shadow
+    protected float gravityStrength;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    protected void Particle(ClientWorld world, double x, double y, double z, CallbackInfo ci) {
+        this.gravityStrength = 1.0f;
+        RegistryKey<World> worldRegistryKey = world.getRegistryKey();
+        Optional<CelestialBodyType> body = CelestialBodyType.getByDimType(worldRegistryKey);
+        if (body.isPresent()) {
+            this.gravityStrength = body.get().getGravity();
+        } else {
+            // Nether, End, potentially other modded dimensions
+            this.gravityStrength = 1.0f;
+        }
+    }
+}

--- a/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/ClientParticleMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/ClientParticleMixin.java
@@ -19,7 +19,7 @@ public abstract class ClientParticleMixin {
     @Shadow
     protected float gravityStrength;
 
-    @Inject(method = "<init>", at = @At("RETURN"))
+    @Inject(method = "<init>(Lnet/minecraft/client/world/ClientWorld;DDD)V", at = @At("RETURN"))
     protected void Particle(ClientWorld world, double x, double y, double z, CallbackInfo ci) {
         this.gravityStrength = 1.0f;
         RegistryKey<World> worldRegistryKey = world.getRegistryKey();

--- a/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/ClientParticleMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/ClientParticleMixin.java
@@ -26,9 +26,6 @@ public abstract class ClientParticleMixin {
         Optional<CelestialBodyType> body = CelestialBodyType.getByDimType(worldRegistryKey);
         if (body.isPresent()) {
             this.gravityStrength = body.get().getGravity();
-        } else {
-            // Nether, End, potentially other modded dimensions
-            this.gravityStrength = 1.0f;
         }
     }
 }

--- a/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/LivingEntityMixin.java
@@ -43,9 +43,6 @@ public abstract class LivingEntityMixin extends Entity {
         Optional<CelestialBodyType> body = CelestialBodyType.getByDimType(worldRegistryKey);
         if (body.isPresent()) {
             cir.setReturnValue(MathHelper.ceil(((fallDistance / (1 / body.get().getGravity())) - 3.0F - ff) * damageMultiplier));
-        } else {
-            // Nether, End, possibly other dimensions that aren't celestial bodies
-            cir.setReturnValue(MathHelper.ceil((fallDistance - 3.0F - ff) * damageMultiplier));
         }
     }
 }

--- a/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/LivingEntityMixin.java
@@ -17,7 +17,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Mixin({LivingEntity.class})

--- a/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/internal/mixin/LivingEntityMixin.java
@@ -41,10 +41,10 @@ public abstract class LivingEntityMixin extends Entity {
         RegistryKey<World> worldRegistryKey = this.world.getRegistryKey();
         StatusEffectInstance statusEffectInstanc = this.getStatusEffect(StatusEffects.JUMP_BOOST);
         float ff = statusEffectInstanc == null ? 0.0F : (float) (statusEffectInstanc.getAmplifier() + 6);
-        try {
-            CelestialBodyType body = CelestialBodyType.getByDimType(worldRegistryKey).get();
-            cir.setReturnValue(MathHelper.ceil(((fallDistance / (1 / body.getGravity())) - 3.0F - ff) * damageMultiplier));
-        } catch (NoSuchElementException e) {
+        Optional<CelestialBodyType> body = CelestialBodyType.getByDimType(worldRegistryKey);
+        if (body.isPresent()) {
+            cir.setReturnValue(MathHelper.ceil(((fallDistance / (1 / body.get().getGravity())) - 3.0F - ff) * damageMultiplier));
+        } else {
             // Nether, End, possibly other dimensions that aren't celestial bodies
             cir.setReturnValue(MathHelper.ceil((fallDistance - 3.0F - ff) * damageMultiplier));
         }

--- a/src/main/resources/gc-api.mixins.json
+++ b/src/main/resources/gc-api.mixins.json
@@ -9,7 +9,9 @@
   ],
   "client": [
     "ClientWorldMixin",
-    "ClientPlayNetworkHandlerMixin"
+    "ClientPlayNetworkHandlerMixin",
+    "ClientParticleMixin",
+    "ClientBlockDustParticleMixin"
   ],
   "minVersion": "0.1.0",
   "injectors": {


### PR DESCRIPTION
Since these dimensions are not registered celestial bodies, the game crashes. This should fix that by giving a default fall damage multiplier to dimensions not registered as CelestialBodies.